### PR TITLE
Replace deprecated rawgit with unpkg

### DIFF
--- a/ocr/index.html
+++ b/ocr/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../plugins.css">
     <script type='text/javascript' src='ocr.js'></script>
     <script src='https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js'></script>
-    <script src='https://cdn.rawgit.com/naptha/tesseract.js/1.0.7/dist/tesseract.js'></script>
+    <script src='https://unpkg.com/tesseract.js@1.0.7/dist/tesseract.js'></script>
 </head>
 
 <style>


### PR DESCRIPTION
Quote from https://rawgit.com/ :
> If you're currently using RawGit, please stop using it as soon as you can.

[Unpkg is recommended by tesseract.js in their readme.](https://github.com/naptha/tesseract.js#cdn)